### PR TITLE
ENHANCEMENT: Add a hook for extensions after an image has been regenerated

### DIFF
--- a/code/FocusPointImage.php
+++ b/code/FocusPointImage.php
@@ -156,7 +156,9 @@ class FocusPointImage extends DataExtension {
 				$left =  $focusOffsetX;
 				
 				//Generate image
-				return $backend->resizeByHeight($height)->crop($top, $left, $width, $height);
+				$result = $backend->resizeByHeight($height)->crop($top, $left, $width, $height);
+				$this->owner->extend('onAfterCroppedFocusedImageGeneration', $this->owner);
+				return $result;
 				
 			} else if ($widthRatio < $heightRatio) {
 			
@@ -183,12 +185,16 @@ class FocusPointImage extends DataExtension {
 				$top =  $focusOffsetY;
 				
 				//Generate image
-				return $backend->resizeByWidth($width)->crop($top, $left, $width, $height);
+				$result = $backend->resizeByWidth($width)->crop($top, $left, $width, $height);
+				$this->owner->extend('onAfterCroppedFocusedImageGeneration', $this->owner);
+				return $result;
 				
 			} else {
 			
 				//Generate image without cropping
-				return $backend->resize($width,$height);
+				$result = $backend->resize($width,$height);
+				$this->owner->extend('onAfterCroppedFocusedImageGeneration', $this->owner);
+				return $result;
 			}
 		
 		}


### PR DESCRIPTION
A fairly minor change but the reason I would like this is for more efficient cache busting with a page having a has_one relationship with an image, for example PageWithImage.  I was using the LastEdited field on PageWithImage as one of the cache key parameters, but of course when the image is refocused only the LastEdited field of the Image is itself updated, not any associated objects which use the Image.  With the extension hook I am able to alter the LastEdited field of PageWithImage using an extension.
