### PR TITLE
NEW: Optionally re-enable deleting resampled images on focus point change

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ If you are caching page content that includes a CroppedFocusedImage and you edit
 
 SilverStripe FocusPoint provides an easy and automated way to get better results when forcing an image to be a different aspect ratio. I have some vague plans to offer more fine-grained control over individual crops in the future, but until then I recommend checking out Will Morgan's [SilverStripe CropperField](https://github.com/willmorgan/silverstripe-cropperfield) as an alternative.
 
+### Flush generated images on focus point change
+
+You can specify that resampled versions of an image should be flushed when its focus point is changed by setting the `FocusPointImage.flush_on_change` config value. For example:
+
+```yml
+# config.yml
+FocusPointImage:
+  flush_on_change: true
+```
+
 ## Troubleshooting
 
 ### The FocusPoint field in the CMS appears broken
@@ -89,6 +99,8 @@ If the focus point field shows a non-interactive image and a text field with a c
 ### Focus point has been changed but image has not updated
 
 As a cache-busting mechanism this module includes approximate focus point coordinates in generated filenames. This means that if the focus point is updating correctly in the CMS but you're not seeing images change on your website, it's likely that you're viewing cached HTML output and need to invalidate that to see the updated image.
+
+Other SilverStripe modules can also prevent images being regenerated when the focus point is changed. You can work around this by telling SilverStripe to [delete resampled versions of an image when its focus point is changed](#flush-generated-images-on-focus-point-change).
 
 ## To Do
 

--- a/code/FocusPointImage.php
+++ b/code/FocusPointImage.php
@@ -12,6 +12,12 @@ class FocusPointImage extends DataExtension {
 		'FocusX' => '0',
 		'FocusY' => '0'
 	);
+
+	/**
+	 * @var boolean
+	 * @config
+	 */
+	private static $flush_on_change = false;
 	
 	public function updateCMSFields(FieldList $fields) {
 		//Add FocusPoint field for selecting focus
@@ -35,6 +41,13 @@ class FocusPointImage extends DataExtension {
 			$coords = FocusPointField::fieldValueToSourceCoords($this->owner->FocusXY);
 			$this->owner->FocusX = $coords[0];
 			$this->owner->FocusY = $coords[1];
+
+			if (
+				Config::inst()->get(__CLASS__, 'flush_on_change')
+				&& ($this->owner->isChanged('FocusX') || $this->owner->isChanged('FocusY'))
+			) {
+				$this->owner->deleteFormattedImages();
+			}
 		}
 		parent::onBeforeWrite();
 	}


### PR DESCRIPTION
We use this module together with the [responsive images module](https://github.com/heyday/silverstripe-responsive-images), which has its own logic for handling resamples - meaning that the focus point hash isn’t stored in the URL as expected. Because of this, changing the focus point won’t result in a new image being generated. This PR optionally re-enables flushing generated images when the focus point changes (removed in cca804f332f2fe872d6d333f75348aeca1a9d77e).

If you’d rather close this, that’s fine - I don’t feel strongly about this PR and we can always add our own extension on top of this anyway! :)