### PR TITLE
fix(FocusPointImage): Fix issue with CroppedFocusedImage()

### DIFF
--- a/code/FocusPointImage.php
+++ b/code/FocusPointImage.php
@@ -294,6 +294,10 @@ class FocusPointImage extends DataExtension
             return $this->owner;
         } elseif ($cropData = $this->calculateCrop($width, $height)) {
             $img = $this->owner->getFormattedImage('CroppedFocusedImage', $width, $height, $cropData['CropAxis'], $cropData['CropOffset']);
+            if (!$img) {
+                return null;
+            }
+
             // Update FocusPoint
             $img->FocusX = $cropData['x']['FocusPoint'];
             $img->FocusY = $cropData['y']['FocusPoint'];


### PR DESCRIPTION
fix(FocusPointImage): Stop issue where CroppedFocusedImage() doesn't handle the failure case like 'Image::getFormattedImage', as that function implicitly returns null if it cannot find the asset.

PHP7 was throwing a 'Notice' error about implicit object creation.