### PR TITLE
BUGFIX: Fixed issue causing the module to crash when using the ImagickBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ SilverStripe 3.3+ (SS 3.1+ support available in earlier releases)
 
 ## To Do
 
- * ImageMagick support (maybe already works - can anyone confirm?)
  * Internationalisation
  * Advanced cropping options and interfaces (may be an additional module)
  * Auto detect focus point via Imagga API

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -5,6 +5,9 @@ After: 'framework/*','cms/*'
 Image:
   extensions:
     - FocusPointImage
+
 # Injector:
+#   ImagickBackend:
+#     class: "FPImagickBackend"
 #   Image:
 #     class: FPImage

--- a/code/FPImagickBackend.php
+++ b/code/FPImagickBackend.php
@@ -1,0 +1,18 @@
+<?php
+class FPImagickBackend extends ImagickBackend {
+    /**
+     * Crop's part of image.
+     * @param top y position of left upper corner of crop rectangle
+     * @param left x position of left upper corner of crop rectangle
+     * @param width rectangle width
+     * @param height rectangle height
+     * @return ImagickBackend
+     */
+    public function crop($top, $left, $width, $height) {
+        $new = clone $this;
+        $new->cropImage($width, $height, $left, $top);
+        
+        return $new;
+    }
+}
+?>

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -11,3 +11,13 @@ See the [packagist listing](https://packagist.org/packages/jonom/focuspoint) and
 ### Manually
 
 I promise it's worth your time to learn how to use Composer. If painless updating isn't your thing though you can download and extract this project, rename the module folder 'focuspoint', place it in your project root and run a dev/build?flush=1.
+
+
+### Using Focus Point with ImageMagick
+
+If you are using the ImageMagick you must use [injector](https://docs.silverstripe.org/en/developer_guides/extending/injector/) to replace the ImagickBackend with the wrapper FPImagickBackend for compatibility using the below:
+```yml
+Injector:
+  ImagickBackend:
+    class: "FPImagickBackend"
+```


### PR DESCRIPTION
This pull request adds a subclass of ImagickBackend that adds the crop method which was causing a fatal error saying that ImagickBackend::crop() is undefined (#24). ImagickBackend is also swapped out using Injector with this new subclass.

I could open a pull against the framework with similar code however it likely won't get merged until 3.6 (if it happens).