### PR TITLE
Check that we return a preview image

### DIFF
--- a/src/Forms/FocusPointField.php
+++ b/src/Forms/FocusPointField.php
@@ -84,13 +84,16 @@ class FocusPointField extends FieldGroup
             $w = intval($this->config()->get('max_width'));
             $h = intval($this->config()->get('max_height'));
             $previewImage = $this->image->FitMax($w * 2, $h * 2);
-            $state['data'] += [
-                'previewUrl' => $previewImage->URL,
-                'previewWidth' => $previewImage->getWidth(),
-                'previewHeight' => $previewImage->getHeight(),
-                'X' => $this->image->getField($this->getName())->getX(),
-                'Y' => $this->image->getField($this->getName())->getY()
-            ];
+
+            if ($previewImage) {
+                $state['data'] += [
+                    'previewUrl' => $previewImage->URL,
+                    'previewWidth' => $previewImage->getWidth(),
+                    'previewHeight' => $previewImage->getHeight(),
+                    'X' => $this->image->getField($this->getName())->getX(),
+                    'Y' => $this->image->getField($this->getName())->getY()
+                ];
+            }
         }
 
         return $state;


### PR DESCRIPTION
Fixes issue #65 

If the underlying file for an image has been removed this causes an internal server error.

```
Call to a member function getWidth() on null
```

```
            $w = intval($this->config()->get('max_width'));
            $h = intval($this->config()->get('max_height'));
            $previewImage = $this->image->FitMax($w * 2, $h * 2);
            $state['data'] += [
                'previewUrl' => $previewImage->URL,
                'previewWidth' => $previewImage->getWidth(),
                'previewHeight' => $previewImage->getHeight(),
                'X' => $this->image->getField($this->getName())->getX(),
                'Y' => $this->image->getField($this->getName())->getY()
            ];
```
