### PR TITLE
Adjust ImageForm logic to support new behaviour to be introduce in silverstripe/assets 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,32 @@
 
 language: php
 sudo: false
-dist: trusty
+dist: xenial
+
+services:
+  - mysql
+  - postgresql
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=3.0.x-dev
+    - COMPOSER_ROOT_VERSION=3.x-dev
     - SS_ENVIRONMENT_TYPE="dev"
+    - DB=MYSQL
 
 matrix:
   include:
     - php: 5.6
       env:
-        - DB=MYSQL
+        - ASSET_VERSION=1.4.x-dev
     - php: 7.1
       env:
         - DB=PGSQL
+    - php: 7.3
+      env:
+        - ASSET_VERSION=1.5.x-dev
+    - php: 7.4
+      env:
+        - ASSET_VERSION=1.x-dev
 
 before_script:
   # Init PHP
@@ -27,8 +38,11 @@ before_script:
   # Install composer dependencies
   - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
-  - composer install --prefer-source
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:^2.2 --prefer-source; fi
+  - composer require silverstripe/assets $ASSET_VERSION --no-update
+  - composer require silverstripe/asset-admin $ASSET_VERSION --no-update
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:^2.2 --no-update; fi
+  - composer update --prefer-source
+
 
 script:
   - vendor/bin/phpunit

--- a/src/Extensions/FocusPointAssetFormFactoryExtension.php
+++ b/src/Extensions/FocusPointAssetFormFactoryExtension.php
@@ -23,12 +23,16 @@ class FocusPointAssetFormFactoryExtension extends Extension
         $image = isset($context['Record']) ? $context['Record'] : null;
         if ($image && $image->appCategory() === 'image') {
             $fpField = FocusPointField::create('FocusPoint', $image->fieldLabel('FocusPoint'), $image);
-            $titleField = $fields->dataFieldByName('Title');
-            if ($titleField && $titleField->isReadonly()) $fpField = $fpField->performReadonlyTransformation();
-            $fields->insertAfter(
-                'Title',
-                $fpField
-            );
+
+            $titleField = $fields->fieldByName('Editor.Details.Title');
+            if ($titleField) {
+                if ($titleField->isReadonly()) $fpField = $fpField->performReadonlyTransformation();
+                $fields->insertAfter(
+                    'Title',
+                    $fpField
+                );
+            }
+
         }
     }
 }

--- a/tests/Extensions/FocusPointAssetFormFactoryExtensionTest.php
+++ b/tests/Extensions/FocusPointAssetFormFactoryExtensionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace JonoM\FocusPoint\Tests\Extensions;
+
+
+use JonoM\FocusPoint\Extensions\FocusPointAssetFormFactoryExtension;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Image;
+use SilverStripe\Control\Controller;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Tab;
+use SilverStripe\Forms\TabSet;
+use SilverStripe\Forms\TextField;
+
+class FocusPointAssetFormFactoryExtensionTest extends SapphireTest
+{
+
+    protected static $fixture_file = '../ImageManipulationTest.yml';
+
+    public function testUpdateFormFieldsOnImageEditForm()
+    {
+        $ext = new FocusPointAssetFormFactoryExtension();
+
+        $fields = FieldList::create(
+            TabSet::create(
+                'Editor',
+                Tab::create(
+                    'Details',
+                    TextField::create('Title')
+                )
+            )
+        );
+        $controller = new Controller();
+        $formName = 'fileEditForm';
+        $context = [
+            'Record' => $this->objFromFixture(Image::class, 'pngLeftTop')
+        ];
+
+
+        $ext->updateFormFields($fields, $controller, $formName, $context);
+
+        $focusField = $fields->fieldByName('Editor.Details.FocusPoint');
+        $this->assertNotEmpty($focusField, 'Focus field has been added to image edit form.');
+    }
+
+    public function testUpdateFormFieldsOnPlacementForm()
+    {
+        $ext = new FocusPointAssetFormFactoryExtension();
+
+        $fields = FieldList::create(
+            TextField::create('Title')
+        );
+        $controller = new Controller();
+        $formName = 'fileEditForm';
+        $context = [
+            'Record' => $this->objFromFixture(Image::class, 'pngLeftTop')
+        ];
+
+
+        $ext->updateFormFields($fields, $controller, $formName, $context);
+
+        $focusField = $fields->fieldByName('Editor.Details.FocusPoint');
+        $this->assertEmpty($focusField, 'Focus field has NOT been added to the form.');
+    }
+
+    public function testUpdateFormFieldsOnNonImageForm()
+    {
+        $ext = new FocusPointAssetFormFactoryExtension();
+
+        $fields = FieldList::create(
+            TabSet::create(
+                'Editor',
+                Tab::create(
+                    'Details',
+                    TextField::create('Title')
+                )
+            )
+        );
+        $controller = new Controller();
+        $formName = 'fileEditForm';
+        $context = [
+            'Record' => $this->objFromFixture(Folder::class, 'folder1')
+        ];
+
+        $ext->updateFormFields($fields, $controller, $formName, $context);
+
+        $focusField = $fields->fieldByName('Editor.Details.FocusPoint');
+        $this->assertEmpty($focusField, 'Focus field has NOT been added to the form.');
+    }
+}


### PR DESCRIPTION
In Silverstripe CMS 4.6, the file modal will allow you to edit files directly. We're also altering the Image Placement form so it no longer displays all the image details, since you can now click on a button to view and edit the details.

This does lead to somewhat weird results when using the focus point module, because it wants to insert a FocusPointField on the image placement form. However, this field is useless because the focus point is control on the Image DataObject.

This PR addresses this problem, by being very specific when adding the FocusPointField. This is backward compatible as well. Existing installation will retain the same behaviour if they upgrade the focus-point module without upgrading to silverstripe-assets 1.6.

# Related PR
* https://github.com/silverstripe/silverstripe-asset-admin/pull/1038
* https://github.com/silverstripe/silverstripe-framework/pull/9425

# Related issue
* https://github.com/silverstripe/silverstripe-asset-admin/issues/813