### PR TITLE
Fix v2-v3 migration task throwing SQL error

### DIFF
--- a/src/Dev/FocusPointMigrationTask.php
+++ b/src/Dev/FocusPointMigrationTask.php
@@ -52,10 +52,10 @@ class FocusPointMigrationTask extends MigrationTask
         }
 
         DB::get_conn()->withTransaction(function() use ($imageTable, $from, $to, $message) {
-            $oldColumnX = "\"$imageTable\".\"{$from}X\"";
-            $oldColumnY = "\"$imageTable\".\"{$from}Y\"";
-            $newColumnX = "\"$imageTable\".\"{$to}X\"";
-            $newColumnY = "\"$imageTable\".\"{$to}Y\"";
+            $oldColumnX = "\"{$from}X\"";
+            $oldColumnY = "\"{$from}Y\"";
+            $newColumnX = "\"{$to}X\"";
+            $newColumnY = "\"{$to}Y\"";
 
             $query = SQLUpdate::create("\"$imageTable\"")
                 ->assignSQL($newColumnX, $oldColumnX)


### PR DESCRIPTION
It seems that the table name shouldn't be prepended to the column in a `DROP COLUMN` call.

The error I was getting was
```
ERROR [Emergency]: Uncaught SilverStripe\ORM\Connect\DatabaseException: Couldn't run query:

ALTER TABLE "Image" DROP COLUMN "Image"."FocusX"

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '."FocusX"' at line 1
```

Using MySQL version 8.0.17
I have not tested on earlier versions.