### PR TITLE
2nd fix prevent [Notice] for #98

### DIFF
--- a/src/FieldType/DBFocusPoint.php
+++ b/src/FieldType/DBFocusPoint.php
@@ -77,7 +77,7 @@ class DBFocusPoint extends DBComposite
             return intval($width);
         }
         if ($this->record) {
-            return intval(is_array($this->record) ? $this->record["Width"] : $this->record->getWidth());
+            return intval(is_array($this->record) ? array_key_exists("Width",$this->record) : $this->record->getWidth());
         }
 
         return 0;
@@ -95,7 +95,7 @@ class DBFocusPoint extends DBComposite
             return intval($height);
         }
         if ($this->record) {
-            return intval(is_array($this->record) ? $this->record["Height"] : $this->record->getHeight());
+            return intval(is_array($this->record) ? array_key_exists("Height",$this->record) : $this->record->getHeight());
         }
         return 0;
     }


### PR DESCRIPTION
with https://github.com/jonom/silverstripe-focuspoint/commit/560254cfc31831b38a4a88483ecbb0b1e5052ad4 merged (4.0.2) now we see `[Notice] Undefined index: Width` instead of `[Emergency] Uncaught Error: Call to a member function getWidth() on array`