### PR TITLE
Set name after parent construct v4 branch

### DIFF
--- a/src/Forms/FocusPointField.php
+++ b/src/Forms/FocusPointField.php
@@ -60,8 +60,8 @@ class FocusPointField extends FieldGroup
             $y->setValue($image->getField($name)->getY());
         }
 
-        $this->setName($name)->setValue('');
         parent::__construct($title, $fields);
+        $this->setName($name)->setValue('');
     }
 
     public function getToolTip()


### PR DESCRIPTION
In php8.1 version of Silverstripe Framework 4.12.7 'name' falls back to autogenerated name from 'title'. This results in name 'Focuspoint' instead of 'FocusPoint'. Result is that the db field is not found, causing an error in asset browser. If name is set after the construct call the issue this is solved.