### PR TITLE
use clone not chained methods to work with InterventionBackend & vips

### DIFF
--- a/src/FieldType/DBFocusPoint.php
+++ b/src/FieldType/DBFocusPoint.php
@@ -285,14 +285,14 @@ class DBFocusPoint extends DBComposite
         switch ($cropAxis) {
             case 'x':
                 //Generate image
-                return $backend
-                    ->resizeByHeight($height)
-                    ->crop(0, $cropOffset, $width, $height);
+                $backend = $backend->resizeByHeight($height);
+                $backendCopy = clone $backend;
+                return $backendCopy->crop(0, $cropOffset, $width, $height);
             case 'y':
                 //Generate image
-                return $backend
-                    ->resizeByWidth($width)
-                    ->crop($cropOffset, 0, $width, $height);
+                $backend = $backend->resizeByWidth($height);
+                $backendCopy = clone $backend;
+                return $backendCopy->crop($cropOffset, 0, $width, $height);
             default:
                 //Generate image without cropping
                 return $backend->resize($width, $height);


### PR DESCRIPTION
Silverstripe [supports libvips](https://github.com/silverstripe/silverstripe-assets/pull/539) as an image manipulation library per Intervention\Image, but fails with focuspoint. I've made a repo to demonstrate with some details in the readme.

https://github.com/lerni/vanilla-vips

Since Edge 121 now also supports AVIF and libvips does that faster than other drivers, I'm keen to try the new possibilities with https://github.com/silverstripe/silverstripe-assets/pull/585

https://caniuse.com/?search=AVIF